### PR TITLE
chore: update eth-ape>=0.1.0a31 pin in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.1.0a14",
+        "eth-ape>=0.1.0a31",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",


### PR DESCRIPTION
### What I did
update pin in setup.py

### How I did it
update pin in setup.py to "eth-ape>=0.1.0a31"

### How to verify it
review setup.py

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
