### PR TITLE
fix: correct URL in fantom API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Ape Etherscan Plugin
 
-Etherscan Explorer Plugin for Ethereum-based networks.
+The following blockchain explorers are supported in this plugin:
+
+* [Etherscan](https://etherscan.io/) for Ethereum networks.
+* [Ftmscan](https://ftmscan.com) for Fantom networks.
+* [Arbiscan]("https://arbiscan.io") for Arbitrum networks.
 
 ## Dependencies
 
@@ -40,18 +44,20 @@ etherscan URL: https://rinkeby.etherscan.io/tx/0x123321123321123321123321123aaaa
 ## Contract Types
 
 The `ape-etherscan` plugin also assists in fetching `contract_types`.
-Use the `Contract` top-level ape construct to create contract instances.
-When you have an explorer plugin installed and it locates a contract type at the give address, the `Contract` return-value will use that contract type.
+Use the `Contract` top-level construct to create contract instances.
+When the explorer plugin locates a contract type for a given address, the `Contract` return-value uses that contract type.
 
 ```python
 from ape import accounts, Contract
 
-# The following with fetch a contract type from mainnet using the `ape-explorer` plugin.
-# The contract type is then cached to disc (and in memory for the active session) so that subsequent invocations don't require HTTP calls.
-# The return value from `Contract` is a `ContractInstance`, so it is connected to your active provider and ready for transactions.
-contract_from_mainnet = Contract("0x55a8a39bc9694714e2874c1ce77aa1e599461e18")
-receipt = contract_from_mainnet.call_mutable_method("arg0", sender=accounts.load("acct"))
+contract = Contract("0x55a8a39bc9694714e2874c1ce77aa1e599461e18")
+receipt = contract.call_mutable_method("arg0", sender=accounts.load("acct"))
 ```
+
+The first line `contract = Contract("0x55a8a39bc9694714e2874c1ce77aa1e599461e18")` checks if ape has a cached contract-type for the address `0x55a8a39bc9694714e2874c1ce77aa1e599461e18`.
+If it does not find a cached contract type, it uses an explorer plugin to attempt to find one.
+If found, the contract type is then cached to disk and in memory for the active session so that subsequent invocations don't require HTTP calls.
+The return value from `Contract` is a `ContractInstance`, so it is connected to your active provider and ready for transactions.
 
 **NOTE**: Vyper contracts from Etherscan always return the name `Vyper_contract`.
 However, if the plugin detects that the contract type has a method named `symbol`, it will use the return value from that call instead.

--- a/ape_etherscan/exceptions.py
+++ b/ape_etherscan/exceptions.py
@@ -3,7 +3,7 @@ import os
 from ape.exceptions import ApeException
 from requests import Response
 
-from ape_etherscan.utils import API_KEY_ENV_VAR_NAME
+from ape_etherscan.utils import API_KEY_ENV_KEY_MAP
 
 
 class ApeEtherscanException(ApeException):
@@ -38,8 +38,9 @@ class EtherscanTooManyRequestsError(EtherscanResponseError):
 
     def __init__(self, response: Response):
         message = "Etherscan API server rate limit exceeded."
-        if not os.environ.get(API_KEY_ENV_VAR_NAME):
-            message = f"{message}. Try setting environment variable '{API_KEY_ENV_VAR_NAME}'."
+        options = API_KEY_ENV_KEY_MAP.keys()
+        if not any(os.environ.get(o) for o in options):
+            message = f"{message}. Try setting one of '{', '.join(options)}'."
 
         super().__init__(response, message)
 

--- a/ape_etherscan/utils.py
+++ b/ape_etherscan/utils.py
@@ -1,1 +1,5 @@
-API_KEY_ENV_VAR_NAME = "ETHERSCAN_API_KEY"
+API_KEY_ENV_KEY_MAP = {
+    "arbitrum": "ARBISCAN_API_KEY",
+    "ethereum": "ETHERSCAN_API_KEY",
+    "fantom": "FTMSCAN_API_KEY",
+}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ from setuptools import find_packages, setup  # type: ignore
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
-        "ape-fantom",  # NOTE: Needed to test Fantom integration
+        "ape-fantom",  # For testing Fantom integration
+        "ape-arbitrum",  # For testing Arbitrum integration
         "ape-infura",  # Needed for live network tests
         "pytest>=6.0,<7.0",  # Core testing package
         "pytest-xdist",  # multi-process runner
@@ -64,7 +65,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.3.0,<0.4.0",
+        "eth-ape>=0.3.5,<0.4.0",
         "importlib-metadata ; python_version<'3.8'",
         "requests>=2.25.1,<3.0.0",
     ],


### PR DESCRIPTION
### What I did

The base URL for the api client when using Fantom networks was missing the `/api` suffix.
This PR fixes it as well as dusts off the plugin a little bit.

### How I did it

The issue was raised by the community so I addressed it!
I just debugged until I saw what was wrong and then fixed it and included fantom in the tests.

### How to verify it

You should now be able to get contract types from Fantom.

Use a script like this and connect to Fantom:

```python
from operator import ne
from ape import networks
import click


def main():
    provider = networks.provider
    network = provider.network
    assert network.ecosystem.name == "fantom", "Must use fantom"
    explorer = network.explorer
    assert explorer is not None, "Must have explorer (ape-etherscan) installed"
    address = "0x30Ac60fcbD79E03d51199BA87111b95C06e1E82F"
    contract_type = explorer.get_contract_type(address)
    click.echo(contract_type.name)
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
