### PR TITLE
feat: allow specifying multiple api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ python3 setup.py install
 
 ## Quick Usage
 
+## Set up the environment
+
+Specify API keys as environment variables. You could put them in your shell's config like `~/.profile`
+or use a tool like [direnv](https://direnv.net/) and store them locally in `.envrc`.
+
+You can also specify multiple comma-separated keys, a random key will be chosen for each request.
+This could be useful if you hit API rate limits.
+
+You can obtain an API key by registering with Etherscan and visitng [this page](https://etherscan.io/myapikey).
+
+```bash
+export ETHERSCAN_API_KEY=SAMPLE_KEY
+export FTMSCAN_API_KEY=SAMPLE_KEY
+export ARBISCAN_API_KEY=SAMPLE_KEY
+```
+
 ## Transaction URLs
 
 When you have this plugin installed, Etherscan explorer URLs appear in CLI output.

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -123,7 +123,7 @@ class _APIClient:
         api_key = os.environ.get(env_var_key)
         if api_key and (not params_or_data or "apikey" not in params_or_data):
             params_or_data = params_or_data or {}
-            api_key = random.choice(api_key.split(','))
+            api_key = random.choice(api_key.split(","))
             params_or_data["apikey"] = api_key
 
         return params_or_data

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -1,5 +1,6 @@
 import json
 import os
+import random
 from dataclasses import dataclass
 from typing import Dict, Iterator, List, Optional, Union
 
@@ -122,6 +123,7 @@ class _APIClient:
         api_key = os.environ.get(env_var_key)
         if api_key and (not params_or_data or "apikey" not in params_or_data):
             params_or_data = params_or_data or {}
+            api_key = random.choice(api_key.split(','))
             params_or_data["apikey"] = api_key
 
         return params_or_data

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -124,7 +124,7 @@ class _APIClient:
         if api_key and (not params_or_data or "apikey" not in params_or_data):
             params_or_data = params_or_data or {}
             api_key = random.choice(api_key.split(","))
-            params_or_data["apikey"] = api_key
+            params_or_data["apikey"] = api_key.strip()
 
         return params_or_data
 

--- a/ape_etherscan/exceptions.py
+++ b/ape_etherscan/exceptions.py
@@ -38,7 +38,7 @@ class EtherscanTooManyRequestsError(EtherscanResponseError):
 
     def __init__(self, response: Response):
         message = "Etherscan API server rate limit exceeded."
-        options = API_KEY_ENV_KEY_MAP.keys()
+        options = API_KEY_ENV_KEY_MAP.values()
         if not any(os.environ.get(o) for o in options):
             message = f"{message}. Try setting one of '{', '.join(options)}'."
 

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -7,6 +7,8 @@ from ape.api.explorers import ExplorerAPI
 from requests import Response
 
 from ape_etherscan import NETWORKS
+import os
+from ape_etherscan.exceptions import EtherscanTooManyRequestsError
 
 TRANSACTION = "0x0da22730986e96aaaf5cedd5082fea9fd82269e41b0ee020d966aa9de491d2e6"
 MOCK_RESPONSES_PATH = Path(__file__).parent / "mock_responses"
@@ -202,3 +204,10 @@ def test_get_account_transactions(mocker, mock_account_transactions_response, ad
 
     # From `get_account_transactions.json` response.
     assert actual[0].txn_hash == "GENESIS_ddbd2b932c763ba5b1b7ae3b362eac3e8d40121a"
+
+
+def test_too_many_requests_error(mocker):
+    response = mocker.MagicMock()
+    os.environ.pop("ETHERSCAN_API_KEY", None)
+    error = EtherscanTooManyRequestsError(response)
+    assert "ETHERSCAN_API_KEY" in str(error)


### PR DESCRIPTION
### What I did

allow specifying multiple api keys to reduce the chances of hitting rate limits.

### How I did it

split the env var we read by comma and choose a random key from it.

it would be possible to do a round robin key rotation if we read it once and wrap it into `itertools.cycle`, then we can call `next(keys)` every time we need to make a request.

### How to verify it

```
export ETHERSCAN_API_KEY=KEY1,KEY2
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
