### PR TITLE
fix: issue where got response error after verification

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -248,6 +248,8 @@ class SourceVerifier(ManagerAccessMixin):
         }
 
         evm_version = compiler_used.settings.get("evmVersion")
+        license_code = self.license_code
+        license_code_value = None if not license_code else license_code.value
         guid = self._contract_client.verify_source_code(
             source_code,
             compiler_used.version,
@@ -256,7 +258,7 @@ class SourceVerifier(ManagerAccessMixin):
             optimization_runs=runs,
             constructor_arguments=self.constructor_arguments,
             evm_version=evm_version,
-            license_type=self.license_code.value,
+            license_type=license_code_value,
         )
         self._wait_for_verification(guid)
 

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -10,7 +10,7 @@ from ethpm_types import ContractType
 from semantic_version import Version  # type: ignore
 
 from ape_etherscan.client import AccountClient, ClientFactory, ContractClient
-from ape_etherscan.exceptions import ContractVerificationError
+from ape_etherscan.exceptions import ContractVerificationError, EtherscanResponseError
 
 _SPDX_ID_TO_API_CODE = {
     "unlicense": 2,
@@ -269,10 +269,21 @@ class SourceVerifier(ManagerAccessMixin):
                 f"Etherscan plugin missing for network {self.provider.network.name}"
             )
 
+        guid_did_exist = False
+        fail_key = "Fail - "
+        pass_key = "Pass - "
+
         for iteration in range(100):
-            verification_update = self._contract_client.check_verify_status(guid)
-            fail_key = "Fail - "
-            pass_key = "Pass - "
+            try:
+                verification_update = self._contract_client.check_verify_status(guid)
+                guid_did_exist = True
+            except EtherscanResponseError as err:
+                if "Resource not found" in str(err) and guid_did_exist:
+                    # Sometimes, the GUID resource is gone before receiving a passing verification
+                    verification_update = f"{pass_key}Complete"
+                else:
+                    raise  # Original error
+
             if verification_update.startswith(fail_key):
                 err_msg = verification_update.split(fail_key)[-1].strip()
                 raise ContractVerificationError(err_msg)

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -1,8 +1,10 @@
+from typing import Callable
+
 import ape
 import pytest
 
 from ape_etherscan import NETWORKS
-from ape_etherscan.exceptions import EtherscanTooManyRequestsError
+from ape_etherscan.exceptions import EtherscanResponseError, EtherscanTooManyRequestsError
 
 # A map of each mock response to its contract name for testing `get_contract_type()`.
 EXPECTED_CONTRACT_NAME_MAP = {
@@ -11,6 +13,7 @@ EXPECTED_CONTRACT_NAME_MAP = {
     "get_vyper_contract_response": "yvDAI",
 }
 TRANSACTION = "0x0da22730986e96aaaf5cedd5082fea9fd82269e41b0ee020d966aa9de491d2e6"
+PUBLISH_GUID = "123"
 ecosystems_and_networks = pytest.mark.parametrize(
     "ecosystem,network",
     [
@@ -21,6 +24,72 @@ ecosystems_and_networks = pytest.mark.parametrize(
         ("polygon", "mainnet"),
     ],
 )
+
+
+@pytest.fixture
+def verification_params(address):
+    ctor_args = "0000000000000005000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000002a73333362346563316232316330313364393230366536333836653231383935356635616630656533636200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002833623465633162323163303133643932303665363338366532313839353566356166306565336362000000000000000000000000000000000000000000000000"  # noqa: E501
+    return {
+        "action": "verifysourcecode",
+        "codeformat": "solidity-standard-json-input",
+        "constructorArguements": ctor_args,
+        "contractaddress": address,
+        "contractname": "foo.sol:foo",
+        "evmversion": None,
+        "licenseType": 1,
+        "module": "contract",
+        "optimizationUsed": 1,
+        "runs": 200,
+    }
+
+
+@pytest.fixture
+def address_to_verify(address):
+    contract_type = ape.project.get_contract("foo").contract_type
+    ape.chain.contracts._local_contract_types[address] = contract_type
+    return address
+
+
+@pytest.fixture
+def verification_tester_cls():
+    class VerificationTester:
+        counter = 0
+
+        def __init__(self, action_when_found: Callable, threshold: int = 2):
+            self.action_when_found = action_when_found
+            self.threshold = threshold
+
+        def sim(self):
+            # Simulate the contract type waiting in the queue until successful verification
+            if self.counter == self.threshold:
+                return self.action_when_found()
+
+            self.counter += 1
+            return "Pending in the queue"
+
+    return VerificationTester
+
+
+@pytest.fixture
+def setup_verification_test(mock_backend, verification_params, verification_tester_cls):
+    def setup(found_handler: Callable, threshold: int = 2):
+        mock_backend.setup_mock_account_transactions_response()
+        mock_backend.add_handler("POST", "contract", verification_params, return_value=PUBLISH_GUID)
+        verification_tester = verification_tester_cls(found_handler, threshold=threshold)
+        mock_backend.add_handler(
+            "GET", "contract", {"guid": PUBLISH_GUID}, side_effect=verification_tester.sim
+        )
+        return verification_tester
+
+    return setup
+
+
+@pytest.fixture
+def expected_verification_log(address_to_verify):
+    return (
+        "Contract verification successful!\n"
+        f"https://etherscan.io/address/{address_to_verify}#code"
+    )
 
 
 @pytest.mark.parametrize(
@@ -110,47 +179,28 @@ def test_too_many_requests_error(no_api_key, response):
 
 
 def test_publish_contract(
-    mock_backend,
-    address,
     explorer,
+    address_to_verify,
+    setup_verification_test,
+    expected_verification_log,
     caplog,
 ):
-    contract_type = ape.project.get_contract("foo").contract_type
-    ape.chain.contracts._local_contract_types[address] = contract_type
-    guid = "123"
-    mock_backend.setup_mock_account_transactions_response()
-    expected_ctor_args = "0000000000000005000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000002a73333362346563316232316330313364393230366536333836653231383935356635616630656533636200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002833623465633162323163303133643932303665363338366532313839353566356166306565336362000000000000000000000000000000000000000000000000"  # noqa: E501
-    expected_verification_params = {
-        "action": "verifysourcecode",
-        "codeformat": "solidity-standard-json-input",
-        "constructorArguements": expected_ctor_args,
-        "contractaddress": address,
-        "contractname": "foo.sol:foo",
-        "evmversion": None,
-        "licenseType": 1,
-        "module": "contract",
-        "optimizationUsed": 1,
-        "runs": 200,
-    }
-    mock_backend.add_handler("POST", "contract", expected_verification_params, return_value=guid)
+    setup_verification_test(lambda: "Pass - You made it!")
+    explorer.publish_contract(address_to_verify)
+    assert caplog.records[-1].message == expected_verification_log
 
-    class VerificationTester:
-        counter = 0
-        threshold = 3
 
-        def sim(self):
-            # Simulate the contract type waiting in the queue until successful verification
-            if self.counter == self.threshold:
-                return "Pass - You made it!"
+def test_publish_contract_when_guid_not_found_at_end(
+    mocker,
+    explorer,
+    address_to_verify,
+    setup_verification_test,
+    expected_verification_log,
+    caplog,
+):
+    def raise_err():
+        raise EtherscanResponseError(mocker.MagicMock(), "Resource not found")
 
-            self.counter += 1
-            return "Pending in the queue"
-
-    verification_tester = VerificationTester()
-    mock_backend.add_handler(
-        "GET", "contract", {"guid": "123"}, side_effect=verification_tester.sim
-    )
-    explorer.publish_contract(address)
-    assert caplog.records[-1].message == (
-        "Contract verification successful!\n" f"https://etherscan.io/address/{address}#code"
-    )
+    setup_verification_test(raise_err, threshold=1)
+    explorer.publish_contract(address_to_verify)
+    assert caplog.records[-1].message == expected_verification_log


### PR DESCRIPTION
### What I did

Occasionally, you would get a `EtherscanResponseError: Resource not found` when waiting for the verification status because it gets verified in between check. This fixes that.

### How I did it

If guid was validated at least once and we happen upon this error, consider it a passing verification.

### How to verify it

verify some contracts on goerli, that is where I noticed the bug happen.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
