### PR TITLE
fix: allow getting contract types for non-checksummed addresses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
     -   id: flake8
@@ -24,7 +24,7 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests]
+        additional_dependencies: [types-PyYAML, types-requests, types-pkg-resources]
 
 
 default_language_version:

--- a/ape_etherscan/explorer.py
+++ b/ape_etherscan/explorer.py
@@ -29,6 +29,10 @@ class Etherscan(ExplorerAPI):
         return ClientFactory(self.network.ecosystem.name, self.network.name.replace("-fork", ""))
 
     def get_contract_type(self, address: AddressType) -> Optional[ContractType]:
+        if not self.conversion_manager.is_type(address, AddressType):
+            # Handle non-checksummed addresses
+            address = self.conversion_manager.convert(str(address), AddressType)
+
         client = self._client_factory.get_contract_client(address)
         source_code = client.get_source_code()
         abi_string = source_code.abi

--- a/ape_etherscan/explorer.py
+++ b/ape_etherscan/explorer.py
@@ -28,7 +28,7 @@ class Etherscan(ExplorerAPI):
     def _client_factory(self) -> ClientFactory:
         return ClientFactory(self.network.ecosystem.name, self.network.name.replace("-fork", ""))
 
-    def get_contract_type(self, address: str) -> Optional[ContractType]:
+    def get_contract_type(self, address: AddressType) -> Optional[ContractType]:
         client = self._client_factory.get_contract_client(address)
         source_code = client.get_source_code()
         abi_string = source_code.abi

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
@@ -18,8 +18,9 @@ extras_require = {
     ],
     "lint": [
         "black>=22.10.0",  # auto-formatter and linter
-        "mypy>=0.982",  # Static type analyzer
-        "types-requests>=2.28.7",  # NOTE: Needed due to mypy typeshed
+        "mypy==0.982",  # Static type analyzer
+        "types-requests>=2.28.7",  # Needed due to mypy typeshed
+        "types-pkg-resources",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
     ],
@@ -68,7 +69,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.5.2,<0.6",
+        "eth-ape>=0.5.4,<0.6",
         "requests",  # Use same version as eth-ape
     ],
     python_requires=">=3.8,<3.11",

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -144,7 +144,11 @@ def test_get_contract_type_ecosystems_and_networks(
     response = mock_backend.setup_mock_get_contract_type_response("get_contract_response")
     explorer = get_explorer(ecosystem, network)
     actual = explorer.get_contract_type(response.expected_address)
+    contract_type_from_lowered_address = explorer.get_contract_type(
+        response.expected_address.lower()
+    )
     assert actual is not None
+    assert actual == contract_type_from_lowered_address
 
     actual = actual.name
     expected = EXPECTED_CONTRACT_NAME_MAP[response.file_name]


### PR DESCRIPTION
### What I did

Was unable to get contract types when address was not checksummed and I got confused.

### How I did it

Check if address type (which checks if checksum) and if not, convert it.

### How to verify it

`address.lower()` <-- use this as a  value

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
