### PR TITLE
fix: handle `agpl-3.0` without the `-only`

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -24,8 +24,8 @@ _SPDX_ID_TO_API_CODE = {
     "mpl-2.0": 10,
     "osl-3.0": 11,
     "apache 2.0": 12,
+    "agpl-3.0": 13,
     "agpl-3.0-only": 13,
-    "agpl-3.0-later": 13,
     "busl-1.1": 14,
 }
 _SPDX_ID_KEY = "SPDX-License-Identifier: "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ EXPECTED_ACCOUNT_TXNS_PARAMS = {
     "sort": "asc",
 }
 FOO_SOURCE_CODE = """
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.2;
 
 import "@bar/bar.sol";
@@ -47,7 +47,7 @@ contract foo {
 }
 """
 BAR_SOURCE_CODE = """
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.2;
 
 contract bar {


### PR DESCRIPTION
### What I did

Before we required an explicit `-only` on the AGPL-3.0 license. Now, it will assume now. Also removed the `-later` one because I am not sure if that is good to have as the same API code

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
