### PR TITLE
feat: add support for using Etherscan as a Query Engine [APE-636]

### DIFF
--- a/ape_etherscan/__init__.py
+++ b/ape_etherscan/__init__.py
@@ -1,6 +1,7 @@
 from ape import plugins
 
 from .explorer import Etherscan
+from .query import EtherscanQueryEngine
 
 NETWORKS = {
     "ethereum": [
@@ -39,3 +40,8 @@ def explorers():
         for network_name in NETWORKS[ecosystem_name]:
             yield ecosystem_name, network_name, Etherscan
             yield ecosystem_name, f"{network_name}-fork", Etherscan
+
+
+@plugins.register(plugins.QueryPlugin)
+def query_engines():
+    yield EtherscanQueryEngine

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -1,0 +1,67 @@
+from typing import Iterator, Optional
+
+from ape.api import QueryAPI, QueryType, ReceiptAPI
+from ape.api.query import AccountTransactionQuery
+from ape.exceptions import QueryEngineError
+from ape.utils import singledispatchmethod
+
+from ape_etherscan.client import ClientFactory
+
+
+class EtherscanQueryEngine(QueryAPI):
+    @property
+    def _client_factory(self) -> ClientFactory:
+        return ClientFactory(
+            self.provider.network.ecosystem.name,
+            self.provider.network.name.replace("-fork", ""),
+        )
+
+    @singledispatchmethod
+    def estimate_query(self, query: QueryType) -> Optional[int]:  # type: ignore[override]
+        return None
+
+    @estimate_query.register
+    def estimate_account_transaction_query(self, query: AccountTransactionQuery) -> int:
+        # About 15 ms per page of 100 transactions
+        return 1500 * (1 + query.stop_nonce - query.start_nonce) // 100
+
+    @singledispatchmethod
+    def perform_query(self, query: QueryType) -> Iterator:  # type: ignore[override]
+        raise QueryEngineError(
+            f"{self.__class__.__name__} cannot handle {query.__class__.__name__} queries."
+        )
+
+    @perform_query.register
+    def get_account_transactions(self, query: AccountTransactionQuery) -> Iterator[ReceiptAPI]:
+        client = self._client_factory.get_account_client(query.account)
+        chain_id = self.provider.chain_id  # TODO: Cache this somehow [APE-635]
+        for receipt_data in client.get_all_normal_transactions():
+            if "confirmations" in receipt_data:
+                receipt_data["required_confirmations"] = receipt_data.pop("confirmations")
+            if "txreceipt_status" in receipt_data:
+                # NOTE: Etherscan uses `""` for `0` in the receipt status.
+                status = receipt_data.pop("txreceipt_status") or 0
+                receipt_data["status"] = status
+
+            if receipt_data.get("nonce") == "":
+                receipt_data["nonce"] = None
+
+            receipt_data["from"] = self.provider.network.ecosystem.decode_address(
+                receipt_data["from"]
+            )
+            receipt_data["chainId"] = chain_id
+
+            receipt = self.provider.network.ecosystem.decode_receipt(receipt_data)
+
+            # NOTE: Required for `elif` leg to function
+            if receipt.sender != query.account:
+                # Likely ``query.account`` is a contract.
+                # Cache the receipts by their sender instead and skip them here.
+                self.chain_manager.history.append(receipt)
+
+            elif (
+                receipt.transaction.nonce
+                # TODO: Take advantage of nonces somehow to remove this if statement
+                and query.start_nonce <= receipt.transaction.nonce <= query.stop_nonce
+            ):
+                yield receipt


### PR DESCRIPTION
### What I did

Partially a realization that Etherscan already has support for several of the types of queries that are supported in our core data query model, so just enabling support for that

### How I did it

Copy-pasted code from this PR: https://github.com/ApeWorX/ape/pull/1277

### How to verify it

Install Etherscan plugin and it works with `account.history` requests

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
