### PR TITLE
feat: add Avalanche Fuji testnet support [APE-705]

### DIFF
--- a/ape_etherscan/__init__.py
+++ b/ape_etherscan/__init__.py
@@ -25,6 +25,7 @@ NETWORKS = {
     ],
     "avalanche": [
         "mainnet",
+        "fuji",
     ],
     "bsc": [
         "mainnet",

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -92,7 +92,11 @@ def get_etherscan_api_uri(ecosystem_name: str, network_name: str):
             else "https://api-testnet.polygonscan.com/api"
         )
     elif ecosystem_name == "avalanche":
-        return "https://api.snowtrace.io/api"
+        return (
+            "https://api.snowtrace.io/api"
+            if network_name == "mainnet"
+            else "https://api-testnet.snowtrace.io/api"
+        )
     elif ecosystem_name == "bsc":
         return (
             f"https://api-{network_name}.bscscan.com/api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,10 +216,7 @@ class MockEtherscanBackend:
                 "mainnet": com_url("polygonscan"),
                 "mumbai": com_testnet_url("testnet", "polygonscan"),
             },
-            "avalanche": {
-                "mainnet": url("snowtrace"),
-                "fuji": testnet_url("testnet", "snowtrace")
-            },
+            "avalanche": {"mainnet": url("snowtrace"), "fuji": testnet_url("testnet", "snowtrace")},
             "bsc": {
                 "mainnet": com_url("bscscan"),
                 "testnet": com_testnet_url("testnet", "bscscan"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,7 +216,10 @@ class MockEtherscanBackend:
                 "mainnet": com_url("polygonscan"),
                 "mumbai": com_testnet_url("testnet", "polygonscan"),
             },
-            "avalanche": {"mainnet": url("snowtrace")},
+            "avalanche": {
+                "mainnet": url("snowtrace"),
+                "fuji": testnet_url("testnet", "snowtrace")
+            },
             "bsc": {
                 "mainnet": com_url("bscscan"),
                 "testnet": com_testnet_url("testnet", "bscscan"),

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -46,6 +46,7 @@ base_url_test = pytest.mark.parametrize(
         ("polygon", "mumbai", "mumbai.polygonscan.com"),
         ("polygon", "mumbai-fork", "mumbai.polygonscan.com"),
         ("avalanche", "mainnet", "snowtrace.io"),
+        ("avalanche", "fuji", "testnet.snowtrace.io"),
         ("bsc", "mainnet", "bscscan.com"),
         ("bsc", "mainnet-fork", "bscscan.com"),
         ("bsc", "testnet", "testnet.bscscan.com"),


### PR DESCRIPTION
### What I did

As per https://docs.snowtrace.io/v/fuji-snowtrace, adding the Etherscan/Snowtrace API for Avalanche Fuji testnet in client.py

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [X] New test cases have been added and are passing
- [X] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
