### PR TITLE
feat: allow verifying contracts that use libraries [APE-718]

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -296,12 +296,27 @@ class SourceVerifier(ManagerAccessMixin):
 
         build_map(source_id)
 
-        # TODO: Handle linked-libraries
-        return {
+        data = {
             "language": compiler.name.capitalize(),
             "sources": sources,
             "settings": settings,
         }
+        if hasattr(compiler, "libraries") and compiler.libraries:
+            libraries = compiler.libraries
+            index = 1
+            max_libraries = 10
+            for _, library in libraries.items():
+                for name, address in library.items():
+                    if index > max_libraries:
+                        raise ContractVerificationError(
+                            f"Can only include up to {max_libraries} libraries."
+                        )
+
+                    data[f"libraryname{index}"] = name
+                    data[f"libraryaddress{index}"] = address
+                    index += 1
+
+        return data
 
     def _wait_for_verification(self, guid: str):
         explorer = self.provider.network.explorer

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.3,<0.7",
+        "eth-ape>=0.6.5,<0.7",
         "requests",  # Use same version as eth-ape
     ],
     python_requires=">=3.8,<3.11",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.5,<0.7",
+        "eth-ape>=0.6.6,<0.7",
         "requests",  # Use same version as eth-ape
     ],
     python_requires=">=3.8,<3.11",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<0.7",
+        "eth-ape>=0.6.3,<0.7",
         "requests",  # Use same version as eth-ape
     ],
     python_requires=">=3.8,<3.11",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,12 +76,8 @@ solidity:
 STANDARD_INPUT_JSON = {
     "language": "Solidity",
     "sources": {
-        "foo.sol": {
-            "content": '\n// SPDX-License-Identifier: AGPL-3.0\npragma solidity ^0.8.2;\n\nimport "@bar/bar.sol";\n\nlibrary MyLib {\n    function insert(uint value) public returns (bool) {\n        return true;\n    }\n}\n\ncontract foo {\n    function register(uint value) public {\n        require(MyLib.insert(value));\n    }\n}\n'  # noqa: E501
-        },
-        ".cache/bar/local/bar.sol": {
-            "content": "\n// SPDX-License-Identifier: AGPL-3.0\npragma solidity ^0.8.2;\n\ncontract bar {\n}\n"  # noqa: E501
-        },
+        "foo.sol": {"content": FOO_SOURCE_CODE},
+        ".cache/bar/local/bar.sol": {"content": BAR_SOURCE_CODE},
     },
     "settings": {
         "optimizer": {"enabled": True, "runs": 200},
@@ -99,8 +95,6 @@ STANDARD_INPUT_JSON = {
 @pytest.fixture(autouse=True)
 def connection(explorer):
     with ape.networks.ethereum.mainnet.use_provider("infura") as provider:
-        provider.network.name = "mainnet"
-        provider.network.explorer = explorer
         yield provider
 
 
@@ -137,6 +131,12 @@ def address():
 @pytest.fixture(scope="session")
 def account():
     return ape.accounts.test_accounts[0]
+
+
+@pytest.fixture(scope="session")
+def fake_connection():
+    with ape.networks.ethereum.local.use_provider("test"):
+        yield
 
 
 @pytest.fixture
@@ -379,7 +379,7 @@ def verification_params(address_to_verify):
 
 
 @pytest.fixture(scope="session")
-def address_to_verify(connection, project, account):
+def address_to_verify(fake_connection, project, account):
     # Deploy the library first.
     library = account.deploy(project.MyLib)
     ape.chain.contracts._local_contract_types[library.address] = library.contract_type

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -164,6 +164,7 @@ def test_publish_contract(
     setup_verification_test,
     expected_verification_log,
     caplog,
+    fake_connection,
 ):
     setup_verification_test(lambda: "Pass - You made it!")
     explorer.publish_contract(address_to_verify)

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -76,9 +76,11 @@ def verification_tester_cls():
 
 
 @pytest.fixture
-def setup_verification_test(mock_backend, verification_params, verification_tester_cls):
+def setup_verification_test(
+    mock_backend, verification_params, verification_tester_cls, address_to_verify
+):
     def setup(found_handler: Callable, threshold: int = 2):
-        mock_backend.setup_mock_account_transactions_response()
+        mock_backend.setup_mock_account_transactions_response(address=address_to_verify)
         mock_backend.add_handler("POST", "contract", verification_params, return_value=PUBLISH_GUID)
         verification_tester = verification_tester_cls(found_handler, threshold=threshold)
         mock_backend.add_handler(


### PR DESCRIPTION
### What I did

formerly https://github.com/ApeWorX/ape-etherscan/pull/70 but pushed upstream for tests

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
