### PR TITLE
feat: add Fuji explorer URL [APE-719]

### DIFF
--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -48,9 +48,7 @@ def get_etherscan_uri(ecosystem_name: str, network_name: str):
         )
     elif ecosystem_name == "avalanche":
         return (
-            "https://snowtrace.io"
-            if network_name == "mainnet"
-            else "https://testnet.snowtrace.io"
+            "https://snowtrace.io" if network_name == "mainnet" else "https://testnet.snowtrace.io"
         )
     elif ecosystem_name == "bsc":
         return (

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -47,7 +47,11 @@ def get_etherscan_uri(ecosystem_name: str, network_name: str):
             else "https://mumbai.polygonscan.com"
         )
     elif ecosystem_name == "avalanche":
-        return "https://snowtrace.io"
+        return (
+            "https://snowtrace.io"
+            if network_name == "mainnet"
+            else "https://testnet.snowtrace.io"
+        )
     elif ecosystem_name == "bsc":
         return (
             f"https://{network_name}.bscscan.com"


### PR DESCRIPTION
Follow-up of https://github.com/ApeWorX/ape-etherscan/pull/73:
- Add logic to give testnet URL of Snowtrace explorer in case we are using Fuji testnet
