### PR TITLE
fix: ignore account txn query for unsupported networks

### DIFF
--- a/ape_etherscan/__init__.py
+++ b/ape_etherscan/__init__.py
@@ -2,38 +2,7 @@ from ape import plugins
 
 from .explorer import Etherscan
 from .query import EtherscanQueryEngine
-
-NETWORKS = {
-    "ethereum": [
-        "mainnet",
-        "goerli",
-        "sepolia",
-    ],
-    "arbitrum": [
-        "mainnet",
-        "goerli",
-    ],
-    "fantom": [
-        "opera",
-        "testnet",
-    ],
-    "optimism": [
-        "mainnet",
-        "goerli",
-    ],
-    "polygon": [
-        "mainnet",
-        "mumbai",
-    ],
-    "avalanche": [
-        "mainnet",
-        "fuji",
-    ],
-    "bsc": [
-        "mainnet",
-        "testnet",
-    ],
-}
+from .utils import NETWORKS
 
 
 @plugins.register(plugins.ExplorerPlugin)

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -1,6 +1,7 @@
 from typing import Iterator, Optional
 
 from ape.api import QueryAPI, QueryType, ReceiptAPI
+from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.api.query import AccountTransactionQuery
 from ape.exceptions import QueryEngineError
 from ape.utils import singledispatchmethod
@@ -21,7 +22,13 @@ class EtherscanQueryEngine(QueryAPI):
         return None
 
     @estimate_query.register
-    def estimate_account_transaction_query(self, query: AccountTransactionQuery) -> int:
+    def estimate_account_transaction_query(self, query: AccountTransactionQuery) -> Optional[int]:
+        if (
+            self.network_manager.active_provider
+            and self.network_manager.provider.network.name == LOCAL_NETWORK_NAME
+        ):
+            return None
+
         # About 15 ms per page of 100 transactions
         return 1500 * (1 + query.stop_nonce - query.start_nonce) // 100
 

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -1,12 +1,12 @@
 from typing import Iterator, Optional
 
 from ape.api import QueryAPI, QueryType, ReceiptAPI
-from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.api.query import AccountTransactionQuery
 from ape.exceptions import QueryEngineError
 from ape.utils import singledispatchmethod
 
 from ape_etherscan.client import ClientFactory
+from ape_etherscan.utils import NETWORKS
 
 
 class EtherscanQueryEngine(QueryAPI):
@@ -23,11 +23,12 @@ class EtherscanQueryEngine(QueryAPI):
 
     @estimate_query.register
     def estimate_account_transaction_query(self, query: AccountTransactionQuery) -> Optional[int]:
-        if (
-            self.network_manager.active_provider
-            and self.network_manager.provider.network.name == LOCAL_NETWORK_NAME
-        ):
-            return None
+        if self.network_manager.active_provider:
+            # Ignore unsupported networks.
+            ecosystem = self.network_manager.provider.network.ecosystem.name
+            network = self.network_manager.provider.network.name
+            if network not in NETWORKS.get(ecosystem, {}):
+                return None
 
         # About 15 ms per page of 100 transactions
         return 1500 * (1 + query.stop_nonce - query.start_nonce) // 100

--- a/ape_etherscan/utils.py
+++ b/ape_etherscan/utils.py
@@ -7,3 +7,34 @@ API_KEY_ENV_KEY_MAP = {
     "avalanche": "SNOWTRACE_API_KEY",
     "bsc": "BSCSCAN_API_KEY",
 }
+NETWORKS = {
+    "ethereum": [
+        "mainnet",
+        "goerli",
+        "sepolia",
+    ],
+    "arbitrum": [
+        "mainnet",
+        "goerli",
+    ],
+    "fantom": [
+        "opera",
+        "testnet",
+    ],
+    "optimism": [
+        "mainnet",
+        "goerli",
+    ],
+    "polygon": [
+        "mainnet",
+        "mumbai",
+    ],
+    "avalanche": [
+        "mainnet",
+        "fuji",
+    ],
+    "bsc": [
+        "mainnet",
+        "testnet",
+    ],
+}


### PR DESCRIPTION
### What I did

ignore unsupported networks by returning None for query estimation
thanks @fubuloubu for telling me how to start this

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
