### PR TITLE
fix: duplicate libraries key in settings dict

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -249,6 +249,13 @@ class SourceVerifier(ManagerAccessMixin):
             [self._source_path], base_path=self._base_path
         )
         settings = all_settings[version]
+
+        # NOTE: Etherscan verification is picky about outputSelection fields.
+        # If you put `srcmap` related fields, it complains with missing sources.
+        for src_id, output_data in settings["outputSelection"].items():
+            for contract_id, selection in output_data.items():
+                output_data[contract_id] = [x for x in selection if x not in ("srcmap",)]
+
         optimizer = settings.get("optimizer", {})
         optimized = optimizer.get("enabled", False)
         runs = optimizer.get("runs", 200)

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -249,13 +249,6 @@ class SourceVerifier(ManagerAccessMixin):
             [self._source_path], base_path=self._base_path
         )
         settings = all_settings[version]
-
-        # NOTE: Etherscan verification is picky about outputSelection fields.
-        # If you put `srcmap` related fields, it complains with missing sources.
-        for src_id, output_data in settings["outputSelection"].items():
-            for contract_id, selection in output_data.items():
-                output_data[contract_id] = [x for x in selection if x not in ("srcmap",)]
-
         optimizer = settings.get("optimizer", {})
         optimized = optimizer.get("enabled", False)
         runs = optimizer.get("runs", 200)

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -308,6 +308,11 @@ class SourceVerifier(ManagerAccessMixin):
 
         build_map(source_id)
 
+        # "libraries" field not allows in `settings` dict.
+        if "libraries" in settings:
+            # libraries are handled below.
+            settings.pop("libraries")
+
         data = {
             "language": compiler.name.capitalize(),
             "sources": sources,

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.7,<0.7",
+        "eth-ape>=0.6.11,<0.7",
         "requests",  # Use same version as eth-ape
     ],
     python_requires=">=3.8,<4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,8 +85,8 @@ STANDARD_INPUT_JSON = {
     "settings": {
         "optimizer": {"enabled": True, "runs": 200},
         "outputSelection": {
-            "subcontracts/foo.sol": {"*": OUTPUT_SELECTION},
-            ".cache/bar/local/bar.sol": {"*": OUTPUT_SELECTION},
+            "subcontracts/foo.sol": {"*": OUTPUT_SELECTION, "": ["ast"]},
+            ".cache/bar/local/bar.sol": {"*": OUTPUT_SELECTION, "": ["ast"]},
         },
         "remappings": ["@bar=.cache/bar/local"],
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from ape.exceptions import NetworkError
 from ape.logging import logger
 from ape.types import AddressType
 from ape.utils import cached_property
+from ape_solidity._utils import OUTPUT_SELECTION
 from requests import Response
 
 from ape_etherscan import Etherscan
@@ -84,8 +85,8 @@ STANDARD_INPUT_JSON = {
     "settings": {
         "optimizer": {"enabled": True, "runs": 200},
         "outputSelection": {
-            "foo.sol": {"foo": ["abi", "bin", "bin-runtime", "devdoc", "userdoc", "srcmap"]},
-            "bar.sol": {"bar": ["abi", "bin", "bin-runtime", "devdoc", "userdoc", "srcmap"]},
+            "subcontracts/foo.sol": {"*": OUTPUT_SELECTION},
+            ".cache/bar/local/bar.sol": {"*": OUTPUT_SELECTION},
         },
         "remappings": ["@bar=.cache/bar/local"],
     },
@@ -420,7 +421,7 @@ class MockEtherscanBackend:
 
 @pytest.fixture
 def verification_params(address_to_verify):
-    ctor_args = "00002833623465633162323163303133643932303665363338366532313839353566356166306565336362000000000000000000000000000000000000000000000000"  # noqa: E501
+    ctor_args = "000000000000000000000000000000000000000000000000000000000000002833623465633162323163303133643932303665363338366532313839353566356166306565336362000000000000000000000000000000000000000000000000"  # noqa: E501
 
     return {
         "action": "verifysourcecode",


### PR DESCRIPTION
### What I did

updates following https://github.com/ApeWorX/ape-solidity/pull/104
also has everything in https://github.com/ApeWorX/ape-etherscan/pull/89 too so let's merge that first plz

### How I did it

fixed tests, that is all

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
