### PR TITLE
fix: Bug where got assertion error and no-exception to re-raise error [APE-1341]

### DIFF
--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -342,6 +342,9 @@ class ContractClient(_APIClient):
         }
         result = self._get(params=params)
         items = result.value or []
+        if not isinstance(items, list):
+            raise ValueError("Expecting list.")
+
         return [ContractCreationResponse(**item) for item in items]
 
 

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -341,9 +341,8 @@ class ContractClient(_APIClient):
             "contractaddresses": [self._address],
         }
         result = self._get(params=params)
-        assert isinstance(result.value, list)
-        assert all(isinstance(val, dict) for val in result.value)
-        return [ContractCreationResponse(**item) for item in result.value]
+        items = result.value or []
+        return [ContractCreationResponse(**item) for item in items]
 
 
 class AccountClient(_APIClient):

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -98,7 +98,6 @@ class EtherscanQueryEngine(QueryAPI):
     def get_contract_creation_receipt(self, query: ContractCreationQuery) -> Iterator[ReceiptAPI]:
         client = self._client_factory.get_contract_client(query.contract)
         creation_data = client.get_creation_data()
-
         if len(creation_data) == 0:
             return
         elif len(creation_data) != 1:

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -99,7 +99,9 @@ class EtherscanQueryEngine(QueryAPI):
         client = self._client_factory.get_contract_client(query.contract)
         creation_data = client.get_creation_data()
 
-        if len(creation_data) != 1:
-            raise
+        if len(creation_data) == 0:
+            return
+        elif len(creation_data) != 1:
+            raise ValueError("Expecting single creation data.")
 
         yield self.chain_manager.get_receipt(creation_data[0].txHash)


### PR DESCRIPTION
### What I did

So I am minding my own business, running tests in Ape core and all of a sudden I get random assertions errors in ape-etherscan for now reason... ok.

I really am easily peeved by assertion errors in production code. That should never happen.

So I go and look and comes to find out we are not handling the empty list case at all. So i fix it, and guess what happens? I get something **even more dreadful**

```
RuntimeError: No active exception to reraise
```

what.... why would there ever be an empty raise statement in production code?
So i go and fix that too.

### How I did it

### How to verify it

Run this test in ape core:

```sh
 pytest tests/functional/test_project.py::test_track_deployment_from_unknown_contract_missing_txn_hash
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
