### PR TITLE
fix: Bug where got assertion error and no-exception to re-raise error [APE-1341]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.6.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.14
+    rev: 0.7.17
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,4 +46,4 @@ A pull request represents the start of a discussion, and doesn't necessarily nee
 If you are opening a work-in-progress pull request to verify that it passes CI tests, please consider
 [marking it as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
 
-Join the Ethereum Python [Discord](https://discord.gg/PcEJ54yX) if you have any questions.
+Join the ApeWorX [Discord](https://discord.gg/apeworx) if you have any questions.

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -98,8 +98,9 @@ class EtherscanQueryEngine(QueryAPI):
     def get_contract_creation_receipt(self, query: ContractCreationQuery) -> Iterator[ReceiptAPI]:
         client = self._client_factory.get_contract_client(query.contract)
         creation_data = client.get_creation_data()
-
-        if len(creation_data) != 1:
-            raise
+        if len(creation_data) == 0:
+            return
+        elif len(creation_data) != 1:
+            raise ValueError("Expecting single creation data.")
 
         yield self.chain_manager.get_receipt(creation_data[0].txHash)

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,16 @@ extras_require = {
         "pytest-mock",  # Test mocker
     ],
     "lint": [
-        "black>=23.3.0,<24",  # auto-formatter and linter
-        "mypy>=0.991,<1",  # Static type analyzer
+        "black>=23.10.0,<24",  # auto-formatter and linter
+        "mypy>=1.6.1,<2",  # Static type analyzer
         "types-requests>=2.28.7",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
-        "flake8>=6.0.0,<7",  # Style linter
+        "flake8>=6.1.0,<7",  # Style linter
         "isort>=5.10.1,<6",  # Import sorting linter
-        "mdformat>=0.7.16",  # Auto-formatter for markdown
+        "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+        "pydantic<2",  # Needed for successful type check.
     ],
     "doc": [
         "Sphinx>=3.4.3,<4",  # Documentation generator


### PR DESCRIPTION
### What I did

Fixes: APE-1341

So I am minding my own business, running tests in Ape core and all of a sudden I get random assertions errors in ape-etherscan for now reason... ok.

I really am easily peeved by assertion errors in production code. That should never happen.

So I go and look and comes to find out we are not handling the empty list case at all. So i fix it, and guess what happens? I get something **even more dreadful**

```
RuntimeError: No active exception to reraise
```

what.... why would there ever be an empty raise statement in production code?
So i go and fix that too.

### How I did it

### How to verify it

Run this test in ape core:

```sh
 pytest tests/functional/test_project.py::test_track_deployment_from_unknown_contract_missing_txn_hash
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
