### PR TITLE
feat: adds support for custom networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,26 @@ Not every network's explorer supports multi-file verification.
 For those networks, the corresponding compiler plugin's `flatten` functionality is invoked, in order to verify the contract as a single file.
 
 **NOTE**: You must set an Etherscan API key environment variable to use the publishing feature.
+
+## Custom Networks
+
+If you would like to use ape-etherscan with your [custom network configuration](https://docs.apeworx.io/ape/stable/userguides/networks.html#custom-network-connection), you can use the same network identifier you used to configure it.  For instance, with a custom Ethereum network called "apechain" your configuration might look something like this:
+
+```yaml
+networks:
+  custom:
+    - name: apechain
+      chain_id: 31337
+
+geth:
+  ethereum:
+    apechain:
+      uri: http://localhost:8545
+
+etherscan:
+  ethereum:
+    rate_limit: 15
+    apechain:
+      uri: https://custom.scan
+      api_uri: https://api.custom.scan/api
+```

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ For those networks, the corresponding compiler plugin's `flatten` functionality 
 
 ## Custom Networks
 
-If you would like to use ape-etherscan with your [custom network configuration](https://docs.apeworx.io/ape/stable/userguides/networks.html#custom-network-connection), you can use the same network identifier you used to configure it.  For instance, with a custom Ethereum network called "apechain" your configuration might look something like this:
+If you would like to use ape-etherscan with your [custom network configuration](https://docs.apeworx.io/ape/stable/userguides/networks.html#custom-network-connection), you can use the same network identifier you used to configure it.
+For instance, with a custom Ethereum network called "apechain" your configuration might look something like this:
 
 ```yaml
 networks:

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -34,11 +34,13 @@ def get_network_config(
     return None
 
 
-def get_etherscan_uri(etherscan_config: EtherscanConfig, ecosystem_name: str, network_name: str):
+def get_etherscan_uri(
+    etherscan_config: EtherscanConfig, ecosystem_name: str, network_name: str
+) -> str:
     # Look for explicitly configured Etherscan config
     network_conf = get_network_config(etherscan_config, ecosystem_name, network_name)
     if network_conf and hasattr(network_conf, "uri"):
-        return network_conf.uri
+        return str(network_conf.uri)
 
     if ecosystem_name == "ethereum":
         return (
@@ -102,11 +104,11 @@ def get_etherscan_uri(etherscan_config: EtherscanConfig, ecosystem_name: str, ne
 
 def get_etherscan_api_uri(
     etherscan_config: EtherscanConfig, ecosystem_name: str, network_name: str
-):
+) -> str:
     # Look for explicitly configured Etherscan config
     network_conf = get_network_config(etherscan_config, ecosystem_name, network_name)
     if network_conf and hasattr(network_conf, "api_uri"):
-        return network_conf.uri
+        return str(network_conf.api_uri)
 
     if ecosystem_name == "ethereum":
         return (

--- a/ape_etherscan/config.py
+++ b/ape_etherscan/config.py
@@ -20,7 +20,7 @@ class EcosystemConfig(PluginConfig):
     def verify_extras(self) -> "EcosystemConfig":
         if self.__pydantic_extra__:
             for aname in self.__pydantic_extra__.keys():
-                self.__pydantic_extra__[aname] = NetworkConfig.parse_obj(
+                self.__pydantic_extra__[aname] = NetworkConfig.model_validate(
                     self.__pydantic_extra__[aname]
                 )
         return self

--- a/ape_etherscan/config.py
+++ b/ape_etherscan/config.py
@@ -1,12 +1,34 @@
+from typing import Optional
+
 from ape.api.config import PluginConfig
+from pydantic import AnyHttpUrl, model_validator
+from pydantic_settings import SettingsConfigDict
+
+
+class NetworkConfig(PluginConfig):
+    uri: Optional[AnyHttpUrl] = None
+    api_uri: Optional[AnyHttpUrl] = None
 
 
 class EcosystemConfig(PluginConfig):
+    model_config = SettingsConfigDict(extra="allow")
+
     rate_limit: int = 5  # Requests per second
     retries: int = 5  # Number of retries before giving up
 
+    @model_validator(mode="after")
+    def verify_extras(self) -> "EcosystemConfig":
+        if self.__pydantic_extra__:
+            for aname in self.__pydantic_extra__.keys():
+                self.__pydantic_extra__[aname] = NetworkConfig.parse_obj(
+                    self.__pydantic_extra__[aname]
+                )
+        return self
+
 
 class EtherscanConfig(PluginConfig):
+    model_config = SettingsConfigDict(extra="allow")
+
     ethereum: EcosystemConfig = EcosystemConfig()
     arbitrum: EcosystemConfig = EcosystemConfig()
     fantom: EcosystemConfig = EcosystemConfig()

--- a/ape_etherscan/query.py
+++ b/ape_etherscan/query.py
@@ -1,11 +1,12 @@
 from typing import Iterator, Optional
 
-from ape.api import QueryAPI, QueryType, ReceiptAPI
+from ape.api import PluginConfig, QueryAPI, QueryType, ReceiptAPI
 from ape.api.query import AccountTransactionQuery, ContractCreationQuery
 from ape.exceptions import QueryEngineError
 from ape.utils import singledispatchmethod
 
-from ape_etherscan.client import ClientFactory
+from ape_etherscan.client import ClientFactory, get_etherscan_api_uri, get_etherscan_uri
+from ape_etherscan.types import EtherscanInstance
 from ape_etherscan.utils import NETWORKS
 
 
@@ -13,6 +14,30 @@ class EtherscanQueryEngine(QueryAPI):
     @property
     def _client_factory(self) -> ClientFactory:
         return ClientFactory(
+            EtherscanInstance(
+                ecosystem_name=self.provider.network.ecosystem.name,
+                network_name=self.provider.network.name.replace("-fork", ""),
+                uri=self.etherscan_uri,
+                api_uri=self.etherscan_api_uri,
+            )
+        )
+
+    @property
+    def _config(self) -> PluginConfig:
+        return self.config_manager.get_config("etherscan")
+
+    @property
+    def etherscan_uri(self):
+        return get_etherscan_uri(
+            self._config,
+            self.provider.network.ecosystem.name,
+            self.provider.network.name.replace("-fork", ""),
+        )
+
+    @property
+    def etherscan_api_uri(self):
+        return get_etherscan_api_uri(
+            self._config,
             self.provider.network.ecosystem.name,
             self.provider.network.name.replace("-fork", ""),
         )

--- a/ape_etherscan/types.py
+++ b/ape_etherscan/types.py
@@ -9,6 +9,8 @@ from ape_etherscan.exceptions import EtherscanResponseError, get_request_error
 
 @dataclass
 class EtherscanInstance:
+    """Used to pass around Etherscan instance information"""
+
     ecosystem_name: str
     network_name: str  # normalized (e.g. no -fork)
     uri: str

--- a/ape_etherscan/types.py
+++ b/ape_etherscan/types.py
@@ -8,6 +8,14 @@ from ape_etherscan.exceptions import EtherscanResponseError, get_request_error
 
 
 @dataclass
+class EtherscanInstance:
+    ecosystem_name: str
+    network_name: str  # normalized (e.g. no -fork)
+    uri: str
+    api_uri: str
+
+
+@dataclass
 class SourceCodeResponse:
     abi: str = ""
     name: str = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.7.0,<0.8",
+        "eth-ape>=0.7.5,<0.8",
         "ethpm_types",  # Use same version as eth-ape
         "requests",  # Use same version as eth-ape
         "yarl",  # Use same version as eth-ape

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ extras_require = {
         "mypy>=1.7.1,<2",  # Static type analyzer
         "types-requests>=2.28.7",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
+        "types-PyYAML",  # Needed due to mypy typeshed
         "flake8>=6.1.0,<7",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     url="https://github.com/ApeWorX/ape-etherscan",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.7.5,<0.8",
+        "eth-ape>=0.7.6,<0.8",
         "ethpm_types",  # Use same version as eth-ape
         "requests",  # Use same version as eth-ape
         "yarl",  # Use same version as eth-ape

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -1,0 +1,10 @@
+from ape_etherscan import NETWORKS
+
+# Every supported ecosystem / network combo as `[("ecosystem", "network") ... ]`
+ecosystems_and_networks = [
+    p
+    for plist in [
+        [(e, n) for n in nets] + [(e, f"{n}-fork") for n in nets] for e, nets in NETWORKS.items()
+    ]
+    for p in plist
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,24 @@ def connection(explorer):
         yield provider
 
 
+@pytest.fixture
+def mock_provider(mocker):
+    @contextmanager
+    def func(ecosystem_name="ethereum", network_name="mock"):
+        mock_provider = mocker.MagicMock()
+        mock_provider.network = mocker.MagicMock()
+        mock_provider.network.name = network_name
+        mock_provider.network.ecosystem = mocker.MagicMock()
+        mock_provider.network.ecosystem.name = ecosystem_name
+        ape.networks.active_provider = mock_provider
+
+        yield mock_provider
+
+        ape.networks.active_provider = None
+
+    return func
+
+
 def make_source(base_dir: Path, name: str, content: str):
     source_file = base_dir / f"{name}.sol"
     source_file.touch()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import yaml
 from contextlib import contextmanager
 from io import StringIO
 from json import JSONDecodeError
@@ -13,6 +12,7 @@ from unittest.mock import MagicMock
 import _io  # type: ignore
 import ape
 import pytest
+import yaml
 from ape.api import ExplorerAPI
 from ape.exceptions import NetworkError
 from ape.logging import logger

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,7 +188,7 @@ def get_explorer(mocker):
     ) -> ExplorerAPI:
         try:
             ecosystem = ape.networks.get_ecosystem(ecosystem_name)
-        except NetworkError as err:
+        except NetworkError:
             # Use mock
             logger.warning(
                 f"Ecosystem 'ape-{ecosystem_name}' not installed; resorting to a mock ecosystem."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,7 @@ def test_config_retries(account, get_explorer, temp_config):
         assert client._retries == 321
 
 
-def test_config_uri(account, get_explorer, temp_config):
+def test_config_uri(account, get_explorer, mock_provider, temp_config):
     """
     Make sure URI parameter is used when configured
     """
@@ -69,7 +69,7 @@ def test_config_uri(account, get_explorer, temp_config):
     }
 
     with temp_config(conf):
-        with ape.networks.ethereum.monkechain.use_provider("geth"):
+        with mock_provider("ethereum", "monkechain"):
             assert account.query_manager.engines["etherscan"].etherscan_uri == expected_uri
             assert account.query_manager.engines["etherscan"].etherscan_api_uri == expected_api_uri
             account_client = account.query_manager.engines[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,14 +29,14 @@ def test_no_config(account, ecosystem, network, get_explorer, temp_config):
 
 def test_config_rate_limit(account, get_explorer, temp_config):
     """Test that rate limit config is set"""
-    conf = DEFAULT_CONFIG | {"etherscan": {"ethereum": {"rate_limit": 123}}}
+    conf = {**DEFAULT_CONFIG, **{"etherscan": {"ethereum": {"rate_limit": 123}}}}
     with temp_config(conf):
         assert account.query_manager.engines["etherscan"].rate_limit == 123
 
 
 def test_config_retries(account, get_explorer, temp_config):
     """Test that rate limit config is set"""
-    conf = DEFAULT_CONFIG | {"etherscan": {"ethereum": {"retries": 321}}}
+    conf = {**DEFAULT_CONFIG, **{"etherscan": {"ethereum": {"retries": 321}}}}
     with temp_config(conf):
         assert account.query_manager.engines["etherscan"].rate_limit == 5
         client = account.query_manager.engines["etherscan"]._client_factory.get_account_client(
@@ -52,10 +52,15 @@ def test_config_uri(account, get_explorer, temp_config):
     expected_uri = "https://monke.chain/"
     expected_api_uri = "https://api.monke.chain/api"
     custon_network_name = "monkechain"
-    conf = DEFAULT_CONFIG | {
-        "networks": {"custom": [{"name": custon_network_name, "chain_id": 31337}]},
-        "etherscan": {
-            "ethereum": {custon_network_name: {"uri": expected_uri, "api_uri": expected_api_uri}}
+    conf = {
+        **DEFAULT_CONFIG,
+        **{
+            "networks": {"custom": [{"name": custon_network_name, "chain_id": 31337}]},
+            "etherscan": {
+                "ethereum": {
+                    custon_network_name: {"uri": expected_uri, "api_uri": expected_api_uri}
+                }
+            },
         },
     }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,7 +55,11 @@ def test_config_uri(account, get_explorer, temp_config):
     conf = {
         **DEFAULT_CONFIG,
         **{
-            "networks": {"custom": [{"name": custon_network_name, "chain_id": 31337}]},
+            "networks": {
+                "custom": [
+                    {"name": custon_network_name, "chain_id": 31337, "ecosystem": "ethereum"}
+                ]
+            },
             "etherscan": {
                 "ethereum": {
                     custon_network_name: {"uri": expected_uri, "api_uri": expected_api_uri}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-import ape
 import pytest
 
 from ._utils import ecosystems_and_networks

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+import ape
+import pytest
+
+from ._utils import ecosystems_and_networks
+
+network_ecosystems = pytest.mark.parametrize(
+    "ecosystem,network",
+    ecosystems_and_networks,
+)
+
+DEFAULT_CONFIG = {"name": "ape-etherscan-test"}
+
+
+@network_ecosystems
+def test_no_config(account, ecosystem, network, get_explorer, temp_config):
+    """Test default behavior"""
+    conf = DEFAULT_CONFIG
+    with temp_config(conf):
+        explorer = get_explorer(ecosystem, network)
+        assert explorer.network.name == network
+        assert explorer.network.ecosystem.name == ecosystem
+        assert account.query_manager.engines["etherscan"].rate_limit == 5
+
+        client = account.query_manager.engines["etherscan"]._client_factory.get_account_client(
+            account
+        )
+        assert client._retries == 5
+
+
+def test_config_rate_limit(account, get_explorer, temp_config):
+    """Test that rate limit config is set"""
+    conf = DEFAULT_CONFIG | {"etherscan": {"ethereum": {"rate_limit": 123}}}
+    with temp_config(conf):
+        assert account.query_manager.engines["etherscan"].rate_limit == 123
+
+
+def test_config_retries(account, get_explorer, temp_config):
+    """Test that rate limit config is set"""
+    conf = DEFAULT_CONFIG | {"etherscan": {"ethereum": {"retries": 321}}}
+    with temp_config(conf):
+        assert account.query_manager.engines["etherscan"].rate_limit == 5
+        client = account.query_manager.engines["etherscan"]._client_factory.get_account_client(
+            account
+        )
+        assert client._retries == 321
+
+
+def test_config_uri(account, get_explorer, temp_config):
+    """
+    Make sure URI parameter is used when configured
+    """
+    expected_uri = "https://monke.chain/"
+    expected_api_uri = "https://api.monke.chain/api"
+    custon_network_name = "monkechain"
+    conf = DEFAULT_CONFIG | {
+        "networks": {"custom": [{"name": custon_network_name, "chain_id": 31337}]},
+        "etherscan": {
+            "ethereum": {custon_network_name: {"uri": expected_uri, "api_uri": expected_api_uri}}
+        },
+    }
+
+    with temp_config(conf):
+        with ape.networks.ethereum.monkechain.use_provider("geth"):
+            assert account.query_manager.engines["etherscan"].etherscan_uri == expected_uri
+            assert account.query_manager.engines["etherscan"].etherscan_api_uri == expected_api_uri
+            account_client = account.query_manager.engines[
+                "etherscan"
+            ]._client_factory.get_account_client(account)
+            assert account_client.base_uri == expected_api_uri
+            contract_client = account.query_manager.engines[
+                "etherscan"
+            ]._client_factory.get_contract_client(account)
+            assert contract_client.base_uri == expected_api_uri

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -1,10 +1,13 @@
 from typing import Callable
 
 import pytest
+import ape
 from ape.api.query import AccountTransactionQuery
 
 from ape_etherscan import NETWORKS
 from ape_etherscan.exceptions import EtherscanResponseError, EtherscanTooManyRequestsError
+
+from ._utils import ecosystems_and_networks
 
 # A map of each mock response to its contract name for testing `get_contract_type()`.
 EXPECTED_CONTRACT_NAME_MAP = {
@@ -15,14 +18,6 @@ EXPECTED_CONTRACT_NAME_MAP = {
 TRANSACTION = "0x0da22730986e96aaaf5cedd5082fea9fd82269e41b0ee020d966aa9de491d2e6"
 PUBLISH_GUID = "123"
 
-# Every supported ecosystem / network combo as `[("ecosystem", "network") ... ]`
-ecosystems_and_networks = [
-    p
-    for plist in [
-        [(e, n) for n in nets] + [(e, f"{n}-fork") for n in nets] for e, nets in NETWORKS.items()
-    ]
-    for p in plist
-]
 base_url_test = pytest.mark.parametrize(
     "ecosystem,network,url",
     [

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -1,7 +1,7 @@
 from typing import Callable
 
-import pytest
 import ape
+import pytest
 from ape.api.query import AccountTransactionQuery
 
 from ape_etherscan import NETWORKS

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -1,10 +1,8 @@
 from typing import Callable
 
-import ape
 import pytest
 from ape.api.query import AccountTransactionQuery
 
-from ape_etherscan import NETWORKS
 from ape_etherscan.exceptions import EtherscanResponseError, EtherscanTooManyRequestsError
 
 from ._utils import ecosystems_and_networks


### PR DESCRIPTION
### What I did

Adds support for custom networks.

Depends on https://github.com/ApeWorX/ape/pull/1852

### How I did it

When available, it will read the necessary information from the relevant ecosystem or from configuration.  Example configuration:

```yaml
networks:
  custom:
    - name: customnetwork
      chain_id: 31337
      default_provider: geth

geth:
  ethereum:
    customnetwork:
      uri: http://localhost:8545

etherscan:
  ethereum:
    rate_limit: 15
    customnetwork:
      uri: https://custom.scan
      api_uri: https://api.custom.scan/api
```

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
