### PR TITLE
fix: mistaken import from ape-solidity

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -9,12 +9,12 @@ from ape.contracts import ContractInstance
 from ape.logging import LogLevel, logger
 from ape.types import AddressType
 from ape.utils import ManagerAccessMixin, cached_property
-from ape_solidity.compiler import DEFAULT_OPTIMIZATION_RUNS
 from ethpm_types import Compiler, ContractType
 
 from ape_etherscan.client import AccountClient, ClientFactory, ContractClient
 from ape_etherscan.exceptions import ContractVerificationError, EtherscanResponseError
 
+DEFAULT_OPTIMIZATION_RUNS = 200
 _SPDX_ID_TO_API_CODE = {
     "unlicense": 2,
     "mit": 3,


### PR DESCRIPTION
### What I did
 
looks like we were assuming ape-solidity was installed when we shouldnt be

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
