### PR TITLE
added sepolia to arbitrum in ape_etherscan/utils.py

### DIFF
--- a/ape_etherscan/utils.py
+++ b/ape_etherscan/utils.py
@@ -14,6 +14,7 @@ NETWORKS = {
     "arbitrum": [
         "mainnet",
         "goerli",
+        "sepolia",
     ],
     "avalanche": [
         "mainnet",


### PR DESCRIPTION
### What I did
Added Sepolia network for Arbitrum to be able to successfully publish a contract on sepolia arbiscan.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it
Added `sepolia` to `arbitrum` in the `NETWORKS` dictionary in `ape_etherscan/utils.py` 

### How to verify it
Tested by deploying a contract (with `publish=True`) and specifying '--network arbitrum:sepolia:infura`. Prior to the change I was getting the error `ERROR: (NetworkError) Unable to publish contract - no explorer plugin installed.`. After the change, contract was published successfully on sepolia arbiscan.
### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
