### PR TITLE
feat: base sepolia

### DIFF
--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -77,7 +77,9 @@ def get_etherscan_uri(
         )
     elif ecosystem_name == "base":
         return (
-            "https://basescan.org" if network_name == "mainnet" else "https://goerli.basescan.org"
+            f"https://{network_name}.basescan.org"
+            if network_name != "mainnet"
+            else "https://basescan.org"
         )
     elif ecosystem_name == "polygon":
         return (
@@ -149,9 +151,9 @@ def get_etherscan_api_uri(
         )
     elif ecosystem_name == "base":
         return (
-            "https://api.basescan.org/api"
-            if network_name == "mainnet"
-            else "https://api-goerli.basescan.org/api"
+            f"https://api-{network_name}.basescan.org/api"
+            if network_name != "mainnet"
+            else "https://api.basescan.org/api"
         )
     elif ecosystem_name == "polygon":
         return (

--- a/ape_etherscan/utils.py
+++ b/ape_etherscan/utils.py
@@ -24,6 +24,7 @@ NETWORKS = {
     "base": [
         "mainnet",
         "goerli",
+        "sepolia",
     ],
     "blast": [
         "mainnet",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -296,6 +296,7 @@ class MockEtherscanBackend:
                 "mumbai": com_testnet_url("testnet", "polygonscan"),
             },
             "base": {
+                "sepolia": org_testnet_url("sepolia", "basescan"),
                 "goerli": org_testnet_url("goerli", "basescan"),
                 "mainnet": org_url("basescan"),
             },

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -48,6 +48,7 @@ base_url_test = pytest.mark.parametrize(
         ("polygon-zkevm", "goerli", "testnet-zkevm.polygonscan.com"),
         ("base", "mainnet", "basescan.org"),
         ("base", "goerli", "goerli.basescan.org"),
+        ("base", "sepolia", "sepolia.basescan.org"),
         ("blast", "mainnet", "blastscan.io"),
         ("blast", "sepolia", "sepolia.blastscan.io"),
         ("avalanche", "mainnet", "snowtrace.io"),


### PR DESCRIPTION
### What I did
Added sepolia support for basescan (goerli is deprecated as of 9th February 2024.)
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
