### PR TITLE
fix: viaIR would not verify on etherscan 

### DIFF
--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -15,6 +15,7 @@ from yarl import URL
 from ape_etherscan.config import EtherscanConfig
 from ape_etherscan.exceptions import (
     ContractNotVerifiedError,
+    IncompatibleCompilerSettingsError,
     UnhandledResultError,
     UnsupportedEcosystemError,
     UnsupportedNetworkError,
@@ -342,6 +343,7 @@ class ContractClient(_APIClient):
         evm_version: Optional[str] = None,
         license_type: Optional[int] = None,
         libraries: Optional[dict[str, str]] = None,
+        via_ir: bool = False,
     ) -> str:
         libraries = libraries or {}
         if len(libraries) > 10:
@@ -376,6 +378,9 @@ class ContractClient(_APIClient):
             json_dict[f"libraryname{iterator}"] = lib_name
             json_dict[f"libraryaddress{iterator}"] = lib_address
             iterator += 1
+
+        if code_format == "solidity-single-file" and via_ir:
+            raise IncompatibleCompilerSettingsError("via_ir", via_ir)
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         return str(self._post(json_dict=json_dict, headers=headers).value)

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -380,7 +380,7 @@ class ContractClient(_APIClient):
             iterator += 1
 
         if code_format == "solidity-single-file" and via_ir:
-            raise IncompatibleCompilerSettingsError("via_ir", via_ir)
+            raise IncompatibleCompilerSettingsError("Solidity", "via_ir", via_ir)
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         return str(self._post(json_dict=json_dict, headers=headers).value)

--- a/ape_etherscan/exceptions.py
+++ b/ape_etherscan/exceptions.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from ape.exceptions import ApeException
 from requests import Response
@@ -85,6 +85,16 @@ class ContractVerificationError(ApeEtherscanException):
     """
     An error that occurs when unable to verify or publish a contract.
     """
+
+
+class IncompatibleCompilerSettingsError(ApeEtherscanException):
+    """
+    An error that occurs when unable to verify or publish a contract because viaIR (or some other)
+    is enabled and the compiler settings are not compatible with the API.
+    """
+
+    def __init__(self, setting: str, value: Any):
+        super().__init__(f"Incompatible compiler setting: `{setting}: {value}`")
 
 
 def get_request_error(response: Response, ecosystem: str) -> EtherscanResponseError:

--- a/ape_etherscan/exceptions.py
+++ b/ape_etherscan/exceptions.py
@@ -93,8 +93,8 @@ class IncompatibleCompilerSettingsError(ApeEtherscanException):
     is enabled and the compiler settings are not compatible with the API.
     """
 
-    def __init__(self, setting: str, value: Any):
-        super().__init__(f"Incompatible compiler setting: `{setting}: {value}`")
+    def __init__(self, compiler: str, setting: str, value: Any):
+        super().__init__(f"Incompatible {compiler} setting: '{setting}={value}'.")
 
 
 def get_request_error(response: Response, ecosystem: str) -> EtherscanResponseError:

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -13,7 +13,11 @@ from ape.utils import ManagerAccessMixin, cached_property
 from ethpm_types import Compiler, ContractType
 
 from ape_etherscan.client import AccountClient, ClientFactory, ContractClient
-from ape_etherscan.exceptions import ContractVerificationError, EtherscanResponseError
+from ape_etherscan.exceptions import (
+    ContractVerificationError,
+    EtherscanResponseError,
+    IncompatibleCompilerSettingsError,
+)
 
 DEFAULT_OPTIMIZATION_RUNS = 200
 _SPDX_ID_TO_API_CODE = {
@@ -170,6 +174,11 @@ class LicenseType(Enum):
         return cls.NO_LICENSE
 
 
+class VerificationApproach(Enum):
+    STANDARD_JSON = "STANDARD_JSON"
+    FLATTEN = "FLATTEN"
+
+
 class SourceVerifier(ManagerAccessMixin):
     def __init__(
         self,
@@ -277,36 +286,40 @@ class SourceVerifier(ManagerAccessMixin):
         # Build a default one and hope for the best.
         return Compiler(name=self.compiler_name, contractType=[self.contract_name], version="")
 
-    def attempt_verification(self):
+    def attempt_verification(
+        self, compiler: Optional[Compiler] = None, approach: Optional[VerificationApproach] = None
+    ):
         """
         Attempt to verify the source code.
         If the bytecode is already verified, Etherscan will use the existing bytecode
         and this method will still succeed.
 
+        Args:
+            compiler (ethpm_types.Compiler): Optionally provide the compiler. Defaults to
+              looking it up from Ape.
+            approach (VerificationApproach): The approach to use when verifying. Defaults
+              to figuring it out from settings.
+
         Raises:
             :class:`~ape_etherscan.exceptions.ContractVerificationError`: - When fails
               to validate the contract.
         """
-
         version = str(self.compiler.version)
-
-        # TODO: Fix compiler output in ape-solidity
-        #  and/or add more validation to ethpm_types.Compiler
-        compiler = self.compiler
+        compiler = compiler or self.compiler
         valid = True
         settings = {}
         if compiler:
-            settings = self.compiler.settings or {}
+            settings = compiler.settings or {}
             output_contracts = settings.get("outputSelection", {})
-            for contract_id in self.compiler.contractTypes or []:
+            for contract_id in compiler.contractTypes or []:
                 parts = contract_id.split(":")
-                if len(parts) != 2:
-                    # Bad compiler.
-                    valid = False
-                    continue
+                cname = None
+                if len(parts) == 2:
+                    _, cname = parts
+                elif len(parts) == 1:
+                    cname = parts[0]
 
-                _, cname = parts
-                if cname not in output_contracts:
+                if not cname or cname not in output_contracts:
                     valid = False
                     break
 
@@ -316,12 +329,17 @@ class SourceVerifier(ManagerAccessMixin):
         optimizer = settings.get("optimizer", {})
         optimized = optimizer.get("enabled", False)
         runs = optimizer.get("runs", DEFAULT_OPTIMIZATION_RUNS)
-        viaIR = settings.get("viaIR", False)
-        source_id = self.contract_type.source_id
-        standard_input_json = self._get_standard_input_json(source_id, **settings)
+        viaIR = settings.get("viaIR", settings.get("via_ir", False))
+        source_id = self.contract_type.source_id or ""
+        standard_input_json = self._get_standard_input_json(
+            source_id, approach=approach, **settings
+        )
         evm_version = settings.get("evmVersion")
         license_code = self.license_code
         license_code_value = license_code.value if license_code else None
+
+        if "sourceCode" in standard_input_json and viaIR:
+            raise IncompatibleCompilerSettingsError(compiler.name, "viaIR", viaIR)
 
         if logger.level == LogLevel.DEBUG:
             logger.debug("Dumping standard JSON output:\n")
@@ -356,13 +374,6 @@ class SourceVerifier(ManagerAccessMixin):
 
             else:
                 raise  # this error
-        except ContractVerificationError as err:
-            if "Incompatible compiler setting" in str(err):
-                logger.warning(str(err))
-                return
-
-            else:
-                raise  # this error
 
         self._wait_for_verification(guid)
 
@@ -380,7 +391,9 @@ class SourceVerifier(ManagerAccessMixin):
         # Hack to allow any Version object work.
         return {str(v): s for v, s in all_settings.items() if str(v) == version}[version]
 
-    def _get_standard_input_json(self, source_id: str, **settings) -> dict:
+    def _get_standard_input_json(
+        self, source_id: str, approach: Optional[VerificationApproach] = None, **settings
+    ) -> dict:
         source_path = self.local_project.sources.lookup(source_id)
         compiler = self.compiler_manager.registered_compilers[source_path.suffix]
         sources = {source_id: {"content": source_path.read_text()}}
@@ -405,7 +418,10 @@ class SourceVerifier(ManagerAccessMixin):
             # libraries are handled below.
             settings.pop("libraries")
 
-        if self.provider.network.ecosystem.name in ECOSYSTEMS_VERIFY_USING_JSON:
+        if approach is VerificationApproach.STANDARD_JSON or (
+            approach is None
+            and self.provider.network.ecosystem.name in ECOSYSTEMS_VERIFY_USING_JSON
+        ):
             # Use standard input json format
             data = {
                 "language": compiler.name.capitalize(),

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -327,7 +327,7 @@ class SourceVerifier(ManagerAccessMixin):
         optimizer = settings.get("optimizer", {})
         optimized = optimizer.get("enabled", False)
         runs = optimizer.get("runs", DEFAULT_OPTIMIZATION_RUNS)
-        viaIR = settings.get("viaIR", settings.get("via_ir", False))
+        via_ir = settings.get("viaIR", settings.get("via_ir", False))
         source_id = self.contract_type.source_id or ""
         standard_input_json = self._get_standard_input_json(
             source_id, approach=approach, **settings
@@ -336,8 +336,8 @@ class SourceVerifier(ManagerAccessMixin):
         license_code = self.license_code
         license_code_value = license_code.value if license_code else None
 
-        if "sourceCode" in standard_input_json and viaIR:
-            raise IncompatibleCompilerSettingsError(compiler.name, "viaIR", viaIR)
+        if "sourceCode" in standard_input_json and via_ir:
+            raise IncompatibleCompilerSettingsError(compiler.name, "viaIR", via_ir)
 
         if logger.level == LogLevel.DEBUG:
             logger.debug("Dumping standard JSON output:\n")
@@ -362,7 +362,7 @@ class SourceVerifier(ManagerAccessMixin):
                 constructor_arguments=self.constructor_arguments,
                 evm_version=evm_version,
                 license_type=license_code_value,
-                via_ir=viaIR,
+                via_ir=via_ir,
             )
         except EtherscanResponseError as err:
             if "source code already verified" in str(err):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -478,22 +478,35 @@ class MockEtherscanBackend:
 
 
 @pytest.fixture
-def verification_params(address_to_verify, standard_input_json):
-    ctor_args = ""  # noqa: E501
+def get_base_verification_params():
+    def fn(
+        ctor_args,
+        address,
+        std_json,
+        **kwargs,
+    ):
+        return {
+            "action": "verifysourcecode",
+            "codeformat": "solidity-standard-json-input",
+            "constructorArguements": ctor_args,
+            "contractaddress": address,
+            "contractname": "foo.sol:foo",
+            "evmversion": None,
+            "licenseType": LicenseType.AGLP_3.value,
+            "module": "contract",
+            "optimizationUsed": 1,
+            "runs": 200,
+            "sourceCode": StringIO(json.dumps(std_json)),
+            **kwargs,
+        }
 
-    return {
-        "action": "verifysourcecode",
-        "codeformat": "solidity-standard-json-input",
-        "constructorArguements": ctor_args,
-        "contractaddress": address_to_verify,
-        "contractname": "foo.sol:foo",
-        "evmversion": None,
-        "licenseType": LicenseType.AGLP_3.value,
-        "module": "contract",
-        "optimizationUsed": 1,
-        "runs": 200,
-        "sourceCode": StringIO(json.dumps(standard_input_json)),
-    }
+    return fn
+
+
+@pytest.fixture
+def verification_params(address_to_verify, standard_input_json, get_base_verification_params):
+    ctor_args = ""  # noqa: E501
+    return get_base_verification_params(ctor_args, address_to_verify, standard_input_json)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This was causing me to pull my hair out! It turns out that etherscan's single-file verification has no way to indicate that viaIR was used by the compiler. However, the standard json method DOES. I guess that historically, only ethereum supported this method, but now it appears that at least Base/Blast (only one's I've tested so far) do - but in any case, viaIR would ALWAYS cause failure in single-file mode. Now if single file mode is being used, it raises an exception explaining as much, and verifies otherwise.

### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

Verified contracts. What I don't know how to do is create actual tests for this beyond dogfood. To that end, I planned on generating a simple few contracts to deploy across several ecosystems.

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [X] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
