### PR TITLE
feat: add holesky ethereum network

### DIFF
--- a/ape_etherscan/utils.py
+++ b/ape_etherscan/utils.py
@@ -34,6 +34,7 @@ NETWORKS = {
     ],
     "ethereum": [
         "mainnet",
+        "holesky",
         "sepolia",
     ],
     "fantom": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,7 @@ class MockEtherscanBackend:
         return {
             "ethereum": {
                 "mainnet": url("etherscan"),
+                "holesky": testnet_url("holesky", "etherscan"),
                 "sepolia": testnet_url("sepolia", "etherscan"),
             },
             "arbitrum": {

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -25,6 +25,8 @@ base_url_test = pytest.mark.parametrize(
         ("ethereum", "mainnet-fork", "etherscan.io"),
         ("ethereum", "sepolia", "sepolia.etherscan.io"),
         ("ethereum", "sepolia-fork", "sepolia.etherscan.io"),
+        ("ethereum", "holesky", "holesky.etherscan.io"),
+        ("ethereum", "holesky-fork", "holesky.etherscan.io"),
         ("fantom", "opera", "ftmscan.com"),
         ("fantom", "opera-fork", "ftmscan.com"),
         ("fantom", "testnet", "testnet.ftmscan.com"),


### PR DESCRIPTION
### What I did

Add holesky to list of networks.

Etherscan supports this longstanding Ethereum testnet, so it should work fine. See also https://github.com/ApeWorX/ape/issues/1932 for context.


<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

Check where sepolia is listed. Add holesky alongside.

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
