### PR TITLE
fix: verification pointlessly regenerates settings issue

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -39,7 +39,7 @@ _SPDX_ID_TO_API_CODE = {
 }
 _SPDX_ID_KEY = "SPDX-License-Identifier: "
 
-ECOSYSTEMS_VERIFY_USING_JSON = ("ethereum",)
+ECOSYSTEMS_VERIFY_USING_JSON = ("ethereum", "base", "blast")
 
 
 class LicenseType(Enum):
@@ -289,8 +289,6 @@ class SourceVerifier(ManagerAccessMixin):
 
         version = str(self.compiler.version)
 
-        # TODO: Fix compiler output in ape-solidity
-        #  and/or add more validation to ethpm_types.Compiler
         compiler = self.compiler
         valid = True
         settings = {}
@@ -299,12 +297,12 @@ class SourceVerifier(ManagerAccessMixin):
             output_contracts = settings.get("outputSelection", {})
             for contract_id in self.compiler.contractTypes or []:
                 parts = contract_id.split(":")
-                if len(parts) != 2:
-                    # Bad compiler.
-                    valid = False
-                    continue
+                if len(parts) == 2:
+                    _, cname = parts
 
-                _, cname = parts
+                else:
+                    cname = parts[0]
+
                 if cname not in output_contracts:
                     valid = False
                     break
@@ -357,7 +355,7 @@ class SourceVerifier(ManagerAccessMixin):
 
     def _get_new_settings(self, version: str) -> dict:
         logger.warning(
-            "Settings missing from cached manifest. " "Attempting to re-calculate find settings."
+            "Settings missing from cached manifest. Attempting to re-calculate to find settings."
         )
 
         # Attempt to re-calculate settings.

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -39,7 +39,7 @@ _SPDX_ID_TO_API_CODE = {
 }
 _SPDX_ID_KEY = "SPDX-License-Identifier: "
 
-ECOSYSTEMS_VERIFY_USING_JSON = ("ethereum", "base", "blast")
+ECOSYSTEMS_VERIFY_USING_JSON = ("arbitrum", "base", "blast", "ethereum")
 
 
 class LicenseType(Enum):


### PR DESCRIPTION
### What I did

some of the settings were getting needlessly re-generated because of a fallacy.
also, weird quotes.
also added some of the networks (i am aware of) that support JSON verification, i made sure they work.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
