### PR TITLE
fix: issue with paging account history

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,15 @@ from ape import project
 
 spork_contract_type = project.dependencies["Spork"]["etherscan"].Spork
 ```
+
+# Querying Accounts
+
+Etherscan offers a query-provider plugin for account data.
+Query account transactions from Etherscan using the following syntax:
+
+```python
+from ape import chain
+
+history = chain.history["vitalik.eth"]
+result = history.query("*", engine_to_use="etherscan")
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,6 +278,10 @@ class MockEtherscanBackend:
             "gnosis": {
                 "mainnet": url("gnosisscan"),
             },
+            "scroll": {
+                "mainnet": com_url("scrollscan"),
+                "sepolia": com_testnet_url("sepolia", "scrollscan"),
+            }
         }
 
     def set_network(self, ecosystem: str, network: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,7 +281,7 @@ class MockEtherscanBackend:
             "scroll": {
                 "mainnet": com_url("scrollscan"),
                 "sepolia": com_testnet_url("sepolia", "scrollscan"),
-            }
+            },
         }
 
     def set_network(self, ecosystem: str, network: str):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,52 @@
+import pytest
+from ape.utils import ManagerAccessMixin
+
+from ape_etherscan.client import AccountClient
+from ape_etherscan.types import EtherscanInstance
+
+
+class TestAccountClient(ManagerAccessMixin):
+    @pytest.fixture
+    def instance(self) -> EtherscanInstance:
+        return EtherscanInstance(
+            ecosystem_name="mye-cosystem",
+            network_name="my-network",
+            uri="https://explorer.example.com",
+            api_uri="https://explorer.example.com/api",
+        )
+
+    @pytest.fixture
+    def address(self):
+        return self.account_manager.test_accounts[0]
+
+    @pytest.fixture
+    def mock_session(self, mocker):
+        return mocker.MagicMock()
+
+    @pytest.fixture
+    def account_client(self, mock_session, instance, address):
+        client = AccountClient(instance, address)
+        client.session = mock_session
+        return client
+
+    def test_get_all_normal_transactions(self, mocker, account_client):
+        start_block = 6
+        end_block = 8
+        end_page = 3
+
+        # Setup session.
+        def get_txns(*args, **kwargs):
+            # Make it page a bit.
+            page = kwargs.get("params").get("page")
+            result = [] if page == end_page else [{"page": page}]
+            resp = mocker.MagicMock()
+            resp.json.return_value = {"result": result}
+            return resp
+
+        account_client.session.request.side_effect = get_txns
+
+        fn = account_client.get_all_normal_transactions
+        iterator = fn(start_block=start_block, end_block=end_block, offset=1, sort="desc")
+        actual = [x for x in iterator]
+        expected = [{"page": 1}, {"page": 2}]
+        assert actual == expected

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -57,8 +57,8 @@ base_url_test = pytest.mark.parametrize(
         ("bsc", "testnet-fork", "testnet.bscscan.com"),
         ("gnosis", "mainnet", "gnosisscan.io"),
         ("gnosis", "mainnet-fork", "gnosisscan.io"),
-        ("scroll", "mainnet", "scrollscan.io"),
-        ("scroll", "sepolia", "sepolia.scrollscan.io"),
+        ("scroll", "mainnet", "scrollscan.com"),
+        ("scroll", "sepolia", "sepolia.scrollscan.com"),
     ],
 )
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ape_etherscan.types import EtherscanResponse
+
+
+class TestEtherscanResponse:
+    @pytest.fixture
+    def response(self, mocker):
+        return mocker.MagicMock()
+
+    @pytest.mark.parametrize("value", ([], [{"foo": "bar"}, None]))
+    def test_value(self, response, value):
+        response.json.return_value = {"result": value}
+        resp = EtherscanResponse(response, "my-ecosystem", raise_on_exceptions=False)
+        assert resp.value == value

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,7 +8,7 @@ class TestEtherscanResponse:
     def response(self, mocker):
         return mocker.MagicMock()
 
-    @pytest.mark.parametrize("value", ([], [{"foo": "bar"}, None]))
+    @pytest.mark.parametrize("value", ([], [{"foo": "bar"}], None))
     def test_value(self, response, value):
         response.json.return_value = {"result": value}
         resp = EtherscanResponse(response, "my-ecosystem", raise_on_exceptions=False)


### PR DESCRIPTION
### What I did

the pager for account history was broken.
you would get to the end and it would try the next page anyway, causing a 500 error.

### How I did it

if no more items, break out of the loop

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
