### PR TITLE
fix: Issue with AGPL3-or-later contract verification on Polygon Amoy

### DIFF
--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -42,7 +42,7 @@ _SPDX_ID_TO_API_CODE = {
     "busl-1.1": 14,
 }
 _SPDX_ID_KEY = "SPDX-License-Identifier: "
-ECOSYSTEMS_VERIFY_USING_JSON = ("arbitrum", "base", "blast", "ethereum")
+ECOSYSTEMS_VERIFY_USING_JSON = ("arbitrum", "base", "blast", "ethereum", "polygon")
 
 
 class LicenseType(Enum):

--- a/ape_etherscan/verify.py
+++ b/ape_etherscan/verify.py
@@ -38,7 +38,7 @@ _SPDX_ID_TO_API_CODE = {
     "apache 2.0": 12,
     "agpl-3.0": 13,
     "agpl-3.0-only": 13,
-    "agpl-3.0-later": 13,
+    "agpl-3.0-or-later": 13,
     "busl-1.1": 14,
 }
 _SPDX_ID_KEY = "SPDX-License-Identifier: "


### PR DESCRIPTION
### What I did

- Updated SPDX license identifer for AGPL 3.0 or later, based on allowed list - https://spdx.org/licenses/
- Added "polygon" to list of ecosystems that allow multi-file source verification.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
