### PR TITLE
fix: check for API key before attempting call

### DIFF
--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -366,7 +366,7 @@ class ClientFactory:
         self._instance = instance
 
     @property
-    def has_api_key(self) -> bool:    
+    def has_api_key(self) -> bool:
         return ETHERSCAN_API_KEY_NAME in os.environ
 
     def get_contract_client(self, contract_address: str) -> ContractClient:

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -365,6 +365,10 @@ class ClientFactory:
     def __init__(self, instance: EtherscanInstance):
         self._instance = instance
 
+    @property
+    def has_api_key(self) -> bool:    
+        return ETHERSCAN_API_KEY_NAME in os.environ
+
     def get_contract_client(self, contract_address: str) -> ContractClient:
         return ContractClient(self._instance, contract_address)
 

--- a/ape_etherscan/explorer.py
+++ b/ape_etherscan/explorer.py
@@ -161,7 +161,7 @@ class Etherscan(ExplorerAPI):
                 self._warn_no_api_key = False
 
             return None
-            
+
         try:
             source_code = self._get_source_code(address)
         except ContractNotVerifiedError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import os
 import shutil
@@ -100,6 +101,15 @@ def make_source(base_dir: Path, name: str, content: str):
     source_file = base_dir / f"{name}.sol"
     source_file.touch()
     source_file.write_text(content)
+
+
+@pytest.fixture(scope="session")
+def supported_chain_ids(networks):
+    return [
+        net.chain_id
+        for net in itertools.chain(*(eco.networks.values() for eco in networks.ecosystems.values()))
+        if net.name != "local" and not net.name.endswith("-fork")
+    ]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_etherscan.py
+++ b/tests/test_etherscan.py
@@ -132,7 +132,12 @@ def test_get_transaction_url(chain_id, url, get_explorer):
 
 
 @pytest.mark.parametrize("chain_id", chain_ids)
-def test_get_contract_type_ecosystems_and_networks(mock_backend, chain_id, get_explorer):
+def test_get_contract_type_ecosystems_and_networks(
+    mock_backend, chain_id, get_explorer, supported_chain_ids
+):
+    if chain_id not in supported_chain_ids:
+        pytest.skip()
+
     # This test parametrizes getting contract types across ecosystem / network combos
     mock_backend.set_network(chain_id)
     response = mock_backend.setup_mock_get_contract_type_response("get_contract_response_flattened")


### PR DESCRIPTION
### What I did

Noticed that when installed (as it is by default through `eth-ape[recommended-plugins]`) but without an API key, that it will try (and fail) to fetch contract types through the new API, but fail because the API does not support un-authenticated requests

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
