### PR TITLE
fix(Client): remove extra slash

### DIFF
--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -55,7 +55,7 @@ def get_etherscan_uri(
     # Look for explicitly configured Etherscan config
     network_conf = get_network_config(etherscan_config, ecosystem_name, network_name)
     if network_conf and hasattr(network_conf, "uri"):
-        return str(network_conf.uri)
+        return str(network_conf.uri).rstrip("/")  # NOTE: Displays wrong URI otherwise
 
     chains = get_supported_chains()
     for chain in chains:
@@ -63,7 +63,7 @@ def get_etherscan_uri(
             continue
 
         # Found.
-        return chain["blockexplorer"]
+        return chain["blockexplorer"].rstrip("/")  # NOTE: Displays wrong URI otherwise
 
     raise UnsupportedEcosystemError(ecosystem_name)
 
@@ -74,7 +74,7 @@ def get_etherscan_api_uri(
     # Look for explicitly configured Etherscan config
     network_conf = get_network_config(etherscan_config, ecosystem_name, network_name)
     if network_conf and hasattr(network_conf, "api_uri"):
-        return str(network_conf.api_uri)
+        return str(network_conf.api_uri).rstrip("/")  # NOTE: Displays wrong URI otherwis
 
     chains = get_supported_chains()
     for chain in chains:
@@ -82,7 +82,7 @@ def get_etherscan_api_uri(
             continue
 
         # Found.
-        return chain["apiurl"]
+        return chain["apiurl"].rstrip("/")  # NOTE: Displays wrong URI otherwise
 
     raise UnsupportedEcosystemError(ecosystem_name)
 

--- a/ape_etherscan/client.py
+++ b/ape_etherscan/client.py
@@ -55,7 +55,7 @@ def get_etherscan_uri(
     # Look for explicitly configured Etherscan config
     network_conf = get_network_config(etherscan_config, ecosystem_name, network_name)
     if network_conf and hasattr(network_conf, "uri"):
-        return str(network_conf.uri).rstrip("/")  # NOTE: Displays wrong URI otherwise
+        return str(network_conf.uri).rstrip("/")
 
     chains = get_supported_chains()
     for chain in chains:
@@ -63,7 +63,7 @@ def get_etherscan_uri(
             continue
 
         # Found.
-        return chain["blockexplorer"].rstrip("/")  # NOTE: Displays wrong URI otherwise
+        return chain["blockexplorer"].rstrip("/")
 
     raise UnsupportedEcosystemError(ecosystem_name)
 
@@ -74,7 +74,7 @@ def get_etherscan_api_uri(
     # Look for explicitly configured Etherscan config
     network_conf = get_network_config(etherscan_config, ecosystem_name, network_name)
     if network_conf and hasattr(network_conf, "api_uri"):
-        return str(network_conf.api_uri).rstrip("/")  # NOTE: Displays wrong URI otherwis
+        return str(network_conf.api_uri).rstrip("/")
 
     chains = get_supported_chains()
     for chain in chains:
@@ -82,7 +82,7 @@ def get_etherscan_api_uri(
             continue
 
         # Found.
-        return chain["apiurl"].rstrip("/")  # NOTE: Displays wrong URI otherwise
+        return chain["apiurl"].rstrip("/")
 
     raise UnsupportedEcosystemError(ecosystem_name)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -545,8 +545,7 @@ def address_to_verify_with_ctor_args(contract_to_verify_with_ctor_args):
 def expected_verification_log(address_to_verify):
     return (
         "Contract verification successful!\n"
-        # TODO: Remove double / in https://github.com/ApeWorX/ape-etherscan/pull/163
-        f"https://etherscan.io//address/{address_to_verify}#code"
+        f"https://etherscan.io/address/{address_to_verify}#code"
     )
 
 
@@ -554,6 +553,5 @@ def expected_verification_log(address_to_verify):
 def expected_verification_log_with_ctor_args(address_to_verify_with_ctor_args):
     return (
         "Contract verification successful!\n"
-        # TODO: Remove double / in https://github.com/ApeWorX/ape-etherscan/pull/163
-        f"https://etherscan.io//address/{address_to_verify_with_ctor_args}#code"
+        f"https://etherscan.io/address/{address_to_verify_with_ctor_args}#code"
     )


### PR DESCRIPTION
### What I did

This fixes an issue when it displays the tx or address explorer URLs, it adds an extra slash e.g. `https://etherscan.io//tx/0x...`

Etherscan will not take you to the correct page when this happens

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
